### PR TITLE
Add the ability to share resources between users.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,7 +4,7 @@ class ProjectsController < ApiController
 
   # GET /projects or /projects.json
   def index
-    @projects = current_user.created_projects.all
+    @projects = current_user.user_projects
   end
 
   # GET /projects/1 or /projects/1.json

--- a/app/controllers/shared_resources_controller.rb
+++ b/app/controllers/shared_resources_controller.rb
@@ -1,0 +1,48 @@
+class SharedResourcesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_shared_resource, only: %i[ show ]
+
+  def create
+    @shared_resource = SharedResource.new(shared_resource_params)
+
+     respond_to do |format|
+      if @shared_resource.save
+        format.html { redirect_to @shared_resource, notice: "Resource shared successfully " }
+        format.json { render :show, status: :created, location: @shared_resource }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @shared_resource.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def update_permission
+    shared_resource = SharedResource.find_by(shareable_id: params[:resource_id], user_id: params[:user_id], shareable_type: params[:resource_type])
+
+    if shared_resource.nil?
+      render json: { error: "Shared resource not found" }, status: :not_found and return
+    end
+
+    # Update permission level if found
+    permission_level = params.dig(:shared_resource,:permission_level)
+    if shared_resource.update(permission_level:)
+      render json: { message: "Permission updated successfully", shared_resource: shared_resource }, status: :ok
+    else
+      render json: { error: shared_resource.errors.full_messages }, status: :unprocessable_entity
+    end
+
+  end
+
+  def show
+  end
+
+  private
+
+  def shared_resource_params
+    params.require(:shared_resource).permit(:shareable_id, :shareable_type, :user_id, :permission_level)
+  end
+
+  def set_shared_resource
+    @shared_resource = SharedResource.find(params[:id])
+  end
+end

--- a/app/controllers/shared_resources_controller.rb
+++ b/app/controllers/shared_resources_controller.rb
@@ -17,20 +17,19 @@ class SharedResourcesController < ApplicationController
   end
 
   def update_permission
-    shared_resource = SharedResource.find_by(shareable_id: params[:resource_id], user_id: params[:user_id], shareable_type: params[:resource_type])
-
-    if shared_resource.nil?
-      render json: { error: "Shared resource not found" }, status: :not_found and return
-    end
-
-    # Update permission level if found
-    permission_level = params.dig(:shared_resource,:permission_level)
-    if shared_resource.update(permission_level:)
+    shared_resource = SharedResource.find_or_initialize_by(
+      shareable_type: params[:shareable_type],
+      shareable_id: params[:shareable_id],
+      user_id: params[:user_id]
+    )
+  
+    shared_resource.permission_level = params.dig(:shared_resource, :permission_level)
+  
+    if shared_resource.save
       render json: { message: "Permission updated successfully", shared_resource: shared_resource }, status: :ok
     else
       render json: { error: shared_resource.errors.full_messages }, status: :unprocessable_entity
     end
-
   end
 
   def show

--- a/app/javascript/app/api/useUpdateSharedResource.ts
+++ b/app/javascript/app/api/useUpdateSharedResource.ts
@@ -1,0 +1,25 @@
+import { SharedResource } from "@/models";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { postHeaders } from "./helpers";
+
+export default function useUpdateSharedResource(shared_resource_id?: number | string, shareable_type?: string) {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: async (new_shared_resource: SharedResource) => {
+            const response = await fetch(`/shared_resources/${shareable_type}/${shared_resource_id}/${new_shared_resource.user_id}`, {
+                method: 'PUT',
+                headers: postHeaders(),
+                body: JSON.stringify({ shared_resource: new_shared_resource }),
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to update report');
+            }
+
+            return response.json();
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['shared_resources', shared_resource_id] })
+        },
+    })
+}

--- a/app/javascript/app/application.tsx
+++ b/app/javascript/app/application.tsx
@@ -66,9 +66,12 @@ const WelcomePage = () => <div className="min-h-screen bg-gray-800 text-white fl
 </div>
 
 
-const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-root.render(
-    <React.StrictMode>
-        <Index />
-    </React.StrictMode>
-);
+const root = document.getElementById('root') as HTMLElement;
+
+if (root) {
+    ReactDOM.createRoot(root).render(
+        <React.StrictMode>
+            <Index />
+        </React.StrictMode>
+    );
+}

--- a/app/javascript/app/components/Document.tsx
+++ b/app/javascript/app/components/Document.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { Button } from "@/ui/button"
 import { Card, CardHeader, CardTitle, CardContent } from "@/ui/card"
-import { Avatar, AvatarFallback, AvatarImage } from "@/ui/avatar"
 import { Share2, ArrowLeft, Edit, Upload } from "lucide-react"
 import { useParams } from 'react-router-dom'
 import { ListLoader } from './Projects'
@@ -18,6 +17,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTrigger, DialogTitle } from 
 import { Label } from '@/ui/label'
 import { Input } from '@/ui/input'
 import useUpdateDocument from '@/api/useUpdateDocument'
+import UserAvatar from './shared/UserAvatar'
 
 export default function Component() {
 
@@ -97,13 +97,7 @@ export default function Component() {
                             <div className="flex flex-wrap gap-2">
                                 {usersPending && <ListLoader height={'h-6'} />}
                                 {users?.map?.((user: User) => (
-                                    <div key={user.id} className="flex items-center bg-gray-700 rounded-full px-3 py-1">
-                                        <Avatar className="w-6 h-6 mr-2">
-                                            <AvatarImage src={user.avatar_url} alt={user.name} />
-                                            <AvatarFallback>{user.name.charAt(0)}</AvatarFallback>
-                                        </Avatar>
-                                        <span className="text-sm">{user.name}</span>
-                                    </div>
+                                    <UserAvatar key={user.id} user={user}/>
                                 ))}
                             </div>
                             <Button variant="link" className="mt-2 text-white" onClick={() => handleShare(document)}>

--- a/app/javascript/app/components/Project.tsx
+++ b/app/javascript/app/components/Project.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { Button } from "@/ui/button"
 import { Input } from "@/ui/input"
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/ui/card"
-import { Avatar, AvatarFallback, AvatarImage } from "@/ui/avatar"
 import { Plus, FileText, Upload, Share2, ArrowLeft } from "lucide-react"
 import { Link, useParams } from 'react-router-dom'
 import useFetchProject from '@/api/useFetchProject'
@@ -19,6 +18,7 @@ import ShareDialog from './shared/ShareDialog'
 import Header from './shared/Header'
 import Layout from './shared/Layout'
 import Page from './shared/Page'
+import UserAvatar from "@/components/shared/UserAvatar"
 import useUpdateSharedResource from '@/api/useUpdateSharedResource'
 
 export default function Component() {
@@ -39,7 +39,6 @@ export default function Component() {
     const { mutate } = useUpdateSharedResource(id, 'Project');
 
     const handleUpdateUserPermission = (userId: number, permission: 'full access' | 'edit' | 'view'): void => {
-        console.log('handleUpdateUserPermission', userId, permission);
         const newSharedResource: SharedResource = {
             user_id: userId,
             permission_level: permission,
@@ -70,13 +69,10 @@ export default function Component() {
                             <div className="flex flex-wrap gap-2">
                                 {usersPending && <ListLoader height={'h-6'} />}
                                 {users?.map?.((user: User) => (
-                                    <div key={user.id} className="flex items-center bg-gray-700 rounded-full px-3 py-1">
-                                        <Avatar className="w-6 h-6 mr-2">
-                                            <AvatarImage src={user.avatar_url} alt={user.name} />
-                                            <AvatarFallback>{user.name.charAt(0)}</AvatarFallback>
-                                        </Avatar>
-                                        <span className="text-sm">{user.name}</span>
-                                    </div>
+                                    <UserAvatar
+                                        key={user.id}
+                                        user={user}
+                                    />
                                 ))}
                             </div>
                             <Button variant="link" className="mt-2 text-white" onClick={() => handleShare(project)}>

--- a/app/javascript/app/components/Project.tsx
+++ b/app/javascript/app/components/Project.tsx
@@ -8,7 +8,7 @@ import { Link, useParams } from 'react-router-dom'
 import useFetchProject from '@/api/useFetchProject'
 import { ListLoader } from './Projects'
 import useFetchReports from '@/api/useFetchReports'
-import { Document, Project, User } from '@/models'
+import { Document, Project, SharedResource, User } from '@/models'
 import { Report } from '@/models/Report'
 import { format } from "date-fns";
 import useCreateReport from '@/api/useCreateReport'
@@ -19,6 +19,7 @@ import ShareDialog from './shared/ShareDialog'
 import Header from './shared/Header'
 import Layout from './shared/Layout'
 import Page from './shared/Page'
+import useUpdateSharedResource from '@/api/useUpdateSharedResource'
 
 export default function Component() {
 
@@ -33,6 +34,17 @@ export default function Component() {
     const handleShare = (item: Report | Document | typeof project) => {
         setSharingItem(item);
         setIsShareDialogOpen(true);
+    };
+
+    const { mutate } = useUpdateSharedResource(id, 'Project');
+
+    const handleUpdateUserPermission = (userId: number, permission: 'full access' | 'edit' | 'view'): void => {
+        console.log('handleUpdateUserPermission', userId, permission);
+        const newSharedResource: SharedResource = {
+            user_id: userId,
+            permission_level: permission,
+        };
+        mutate(newSharedResource);
     };
 
     return (
@@ -85,9 +97,7 @@ export default function Component() {
                 title={sharingItem ? sharingItem === project ? `Share Project: ${project.name}` : 'title' in sharingItem ? `Share Report: ${sharingItem.title}` : `Share Document: ${sharingItem.name}` : 'Share'}
                 isOpen={isShareDialogOpen}
                 onClose={() => setIsShareDialogOpen(false)}
-                handleUpdateUserPermission={function (userId: number, permission: 'full access' | 'edit' | 'view'): void {
-                    alert('Function not implemented.')
-                }}
+                handleUpdateUserPermission={handleUpdateUserPermission}
                 handleAddUser={function (): void {
                     alert('Function not implemented.')
                 }}

--- a/app/javascript/app/components/Report.tsx
+++ b/app/javascript/app/components/Report.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { Button } from "@/ui/button"
 import { Card, CardHeader, CardTitle, CardContent } from "@/ui/card"
-import { Avatar, AvatarFallback, AvatarImage } from "@/ui/avatar"
 import { Share2, ArrowLeft, Edit, FileText } from "lucide-react"
 import { useParams } from 'react-router-dom'
 import { ListLoader } from './Projects'
@@ -19,6 +18,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Label } from '@/ui/label'
 import { Input } from '@/ui/input'
 import useUpdateReport from '@/api/useUpdateReport'
+import UserAvatar from './shared/UserAvatar'
 
 export default function Component() {
 
@@ -96,13 +96,7 @@ export default function Component() {
                             <div className="flex flex-wrap gap-2">
                                 {usersPending && <ListLoader height={'h-6'} />}
                                 {users?.map?.((user: User) => (
-                                    <div key={user.id} className="flex items-center bg-gray-700 rounded-full px-3 py-1">
-                                        <Avatar className="w-6 h-6 mr-2">
-                                            <AvatarImage src={user.avatar_url} alt={user.name} />
-                                            <AvatarFallback>{user.name.charAt(0)}</AvatarFallback>
-                                        </Avatar>
-                                        <span className="text-sm">{user.name}</span>
-                                    </div>
+                                    <UserAvatar key={user.id} user={user}/>
                                 ))}
                             </div>
                             <Button variant="link" className="mt-2 text-white" onClick={() => handleShare(report)}>

--- a/app/javascript/app/components/shared/ShareDialog.tsx
+++ b/app/javascript/app/components/shared/ShareDialog.tsx
@@ -85,7 +85,7 @@ export default function ShareDialog({
                             <div className="flex items-center space-x-2">
                                 <Avatar>
                                     <AvatarImage src={user.avatar_url} alt={user.name} />
-                                    <AvatarFallback>{user.name.charAt(0)}</AvatarFallback>
+                                    <AvatarFallback>{user.name?.charAt(0)}</AvatarFallback>
                                 </Avatar>
                                 <div>
                                     <p className="font-medium">{user.name}</p>

--- a/app/javascript/app/components/shared/UserAvatar.tsx
+++ b/app/javascript/app/components/shared/UserAvatar.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/ui/avatar"
+import { User } from "@/models"
+
+const UserAvatar: React.FC<{ user: User }> = ({ user }) => {
+    return (
+        <div key={user.id} className="flex items-center bg-gray-700 rounded-full px-3 py-1">
+            <Avatar className="w-6 h-6 mr-2">
+                <AvatarImage src={user.avatar_url} alt={user.name} />
+                <AvatarFallback>{user.name?.charAt(0)}</AvatarFallback>
+            </Avatar>
+            <span className="text-sm">{user.name || user.email}</span>
+        </div>
+    );
+}
+
+
+export default UserAvatar;

--- a/app/javascript/app/models/SharedResource.ts
+++ b/app/javascript/app/models/SharedResource.ts
@@ -1,0 +1,11 @@
+export type SharedResource = {
+  id?: number;
+  shareable_type?: "Project" | "Document" | "Report";
+  shareable_id?: number;
+  user_id: number;
+  permission_level: 'full access' | 'edit' | 'view';
+  created_at?: string;
+  updated_at?: string;
+}
+
+  

--- a/app/javascript/app/models/index.ts
+++ b/app/javascript/app/models/index.ts
@@ -2,10 +2,12 @@ import { Document } from "@/models/Document";
 import { Report } from "@/models/Report";
 import { Project } from "@/models/Project";
 import { User } from "@/models/User";
+import { SharedResource } from "@/models/SharedResource";
 
 export {
     Document,
     Report,
     Project,
     User,
+    SharedResource
 }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,7 +3,8 @@ class Project < ApplicationRecord
 
   has_many :documents, dependent: :destroy
   has_many :reports, dependent: :destroy
-  
+  has_many :shared_resources, as: :shareable, dependent: :destroy
+
   validates :name, presence: true
   validates :description, presence: true
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,4 +7,17 @@ class Project < ApplicationRecord
 
   validates :name, presence: true
   validates :description, presence: true
+
+  scope :created_by, ->(user) { where(user_id: user.id) }
+ 
+  scope :shared_with, ->(user) {
+    where(id: SharedResource.where(
+      shareable_type: 'Project',
+      user_id: user.id
+    ).select(:shareable_id))
+  }
+
+  scope :accessible_by, ->(user) {
+    created_by(user).or(shared_with(user))
+  }
 end

--- a/app/models/shared_resource.rb
+++ b/app/models/shared_resource.rb
@@ -1,0 +1,9 @@
+class SharedResource < ApplicationRecord
+  belongs_to :user
+  belongs_to :shareable, polymorphic: true
+
+  enum permission_level: { edit: "edit", full_access: "full_access",  view: "view" }
+
+  validates :permission_level, presence: true
+  validates :user_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,6 @@ class User < ApplicationRecord
   has_many :shared_documents, through: :shared_resources, source: :shareable, source_type: 'Document'
 
   def user_projects
-    created_projects + shared_projects
+    Project.accessible_by(self)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,5 +8,13 @@ class User < ApplicationRecord
   has_many :created_projects, class_name: 'Project', inverse_of: :user
   has_many :created_reports, class_name: 'Report', inverse_of: :user
   has_many :created_documents, class_name: 'Document', inverse_of: :user
-  
+
+  has_many :shared_resources
+  has_many :shared_projects, through: :shared_resources, source: :shareable, source_type: 'Project'
+  has_many :shared_reports, through: :shared_resources, source: :shareable, source_type: 'Report'
+  has_many :shared_documents, through: :shared_resources, source: :shareable, source_type: 'Document'
+
+  def user_projects
+    created_projects + shared_projects
+  end
 end

--- a/app/views/shared_resources/_shared_resource.json.jbuilder
+++ b/app/views/shared_resources/_shared_resource.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! shared_resource, :id, :shareable_id, :shareable_type, :user_id, :permission_level, :created_at, :updated_at

--- a/app/views/shared_resources/show.json.jbuilder
+++ b/app/views/shared_resources/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "shared_resources/shared_resource", shared_resource: @shared_resource

--- a/app/views/users/_user.json.jbuilder
+++ b/app/views/users/_user.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! user, :name, :avatar_url, :email, :created_at, :updated_at
+json.extract! user, :id, :name, :avatar_url, :email, :created_at, :updated_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,4 @@
 Rails.application.routes.draw do
-  get 'shared_resources/create'
-
   resources :documents
   resources :reports
 
@@ -12,7 +10,7 @@ Rails.application.routes.draw do
   resources :users, only: [:index]
   resources :shared_resources, only: [:show, :create]
 
-  put 'shared_resources/:resource_type/:resource_id/:user_id', to: 'shared_resources#update_permission'
+  put 'shared_resources/:shareable_type/:shareable_id/:user_id', to: 'shared_resources#update_permission'
 
   devise_for :users
   root 'home#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,18 @@
 Rails.application.routes.draw do
+  get 'shared_resources/create'
 
   resources :documents
   resources :reports
-  
+
   resources :projects do
     resources :documents
     resources :reports
   end
 
   resources :users, only: [:index]
+  resources :shared_resources, only: [:show, :create]
+
+  put 'shared_resources/:resource_type/:resource_id/:user_id', to: 'shared_resources#update_permission'
 
   devise_for :users
   root 'home#index'

--- a/db/migrate/20241031172716_create_shared_resources.rb
+++ b/db/migrate/20241031172716_create_shared_resources.rb
@@ -1,0 +1,11 @@
+class CreateSharedResources < ActiveRecord::Migration[7.1]
+  def change
+    create_table :shared_resources do |t|
+      t.references :shareable, polymorphic: true, null: false
+      t.references :user, null: false
+      t.string :permission_level
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_25_221451) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_31_172716) do
   create_table "documents", force: :cascade do |t|
     t.string "name"
     t.integer "project_id", null: false
@@ -38,6 +38,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_25_221451) do
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_reports_on_project_id"
     t.index ["user_id"], name: "index_reports_on_user_id"
+  end
+
+  create_table "shared_resources", force: :cascade do |t|
+    t.string "shareable_type", null: false
+    t.integer "shareable_id", null: false
+    t.integer "user_id", null: false
+    t.string "permission_level"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["shareable_type", "shareable_id"], name: "index_shared_resources_on_shareable"
+    t.index ["user_id"], name: "index_shared_resources_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/shared_resources.rb
+++ b/spec/factories/shared_resources.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :shared_resource do
+    shareable { project }
+    user
+    permission_level { 'view' }
+  end
+end

--- a/spec/models/shared_resource_spec.rb
+++ b/spec/models/shared_resource_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe SharedResource, type: :model do
+  describe 'associations' do
+    it { should belong_to(:user) }
+    it { should belong_to(:shareable) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:permission_level) }
+    it { should validate_presence_of(:user_id) }
+  end
+
+  describe 'permission_levels' do
+    it 'defines the correct enum values for permission_level' do
+      expect(SharedResource.permission_levels).to eq({
+        'full_access' => 'full_access',
+        'edit' => 'edit',
+        'view' => 'view'
+      })
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,22 +20,19 @@ describe User, type: :model do
         end
 
         context 'when user has shared projects' do
-            let(:shared_project) { create(:project) }
-            let(:shared_resource) { create(:shared_resource, shareable: shared_project, user: user) }
-
-            before { shared_resource }
+            let!(:shared_project) { create(:project) }
+            let!(:shared_resource) { create(:shared_resource, shareable: shared_project, user: user) }
 
             it "returns the user's created projects and shared projects" do
-                expect(user.user_projects).to eq([created_project, shared_project])
+                expect(user.user_projects).to match_array([created_project, shared_project])
             end
         end
 
         context 'when another user tries to access shared projects' do
             let(:another_user) { create(:user) }
             let(:shared_project) { create(:project) }
-            let(:shared_resource) { create(:shared_resource, shareable: shared_project, user: user) }
+            let!(:shared_resource) { create(:shared_resource, shareable: shared_project, user: user) }
 
-            before { shared_resource }
 
             it "does not return the shared project" do
                 expect(another_user.user_projects).to eq([])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,4 +8,38 @@ describe User, type: :model do
         it { should have_many(:created_reports).class_name('Report').inverse_of(:user) }
         it { should have_many(:created_documents).class_name('Document').inverse_of(:user) }
     end
+
+    describe "#user_projects" do
+        let!(:user) { create(:user) }
+        let!(:created_project) { create(:project, user:) }
+
+        context 'when user has no shared projects' do
+            it "returns only the user's created projects" do
+                expect(user.user_projects).to eq([created_project])
+            end
+        end
+
+        context 'when user has shared projects' do
+            let(:shared_project) { create(:project) }
+            let(:shared_resource) { create(:shared_resource, shareable: shared_project, user: user) }
+
+            before { shared_resource }
+
+            it "returns the user's created projects and shared projects" do
+                expect(user.user_projects).to eq([created_project, shared_project])
+            end
+        end
+
+        context 'when another user tries to access shared projects' do
+            let(:another_user) { create(:user) }
+            let(:shared_project) { create(:project) }
+            let(:shared_resource) { create(:shared_resource, shareable: shared_project, user: user) }
+
+            before { shared_resource }
+
+            it "does not return the shared project" do
+                expect(another_user.user_projects).to eq([])
+            end
+        end
+    end
   end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 describe ProjectsController, type: :request do
 
     let(:user) { create(:user) }
-    
+
     before do
         sign_in(user) if user
     end
@@ -30,6 +30,18 @@ describe ProjectsController, type: :request do
             expect(JSON.parse(response.body).length).to eq(1)
         end
 
+        context 'when user has shared projects' do
+            let(:shared_project) { create(:project) }
+            let(:shared_resource) { create(:shared_resource, shareable: shared_project, user: user) }
+
+            before { shared_resource }
+
+            it 'returns shared projects' do
+                get '/projects.json'
+                expect(JSON.parse(response.body).length).to eq(2)
+            end
+        end
+
         context 'when user is not signed in' do
             let(:user) { nil }
             let!(:project) { create(:project)}
@@ -40,7 +52,7 @@ describe ProjectsController, type: :request do
             end
         end
     end
-    
+
     describe 'POST /projects' do
         it 'creates a project' do
             expect {
@@ -64,10 +76,10 @@ describe ProjectsController, type: :request do
             end
         end
     end
-    
+
     describe 'GET /projects/:id' do
         let(:project) { create(:project, user:) }
-    
+
         it 'returns successful' do
             get "/projects/#{project.id}.json"
             expect(response).to be_successful
@@ -97,10 +109,10 @@ describe ProjectsController, type: :request do
             end
         end
     end
-    
+
     describe 'PUT /projects/:id' do
         let(:project) { create(:project, user:) }
-    
+
         it 'updates a project' do
             put "/projects/#{project.id}.json", params: { project: { name: 'Updated Project' } }
             expect(response).to be_successful
@@ -133,10 +145,10 @@ describe ProjectsController, type: :request do
             end
         end
     end
-    
+
     describe 'DELETE /projects/:id' do
         let(:project) { create(:project, user:) }
-    
+
         it 'deletes a project' do
             delete "/projects/#{project.id}.json"
             expect(response).to be_successful

--- a/spec/requests/shared_resources_spec.rb
+++ b/spec/requests/shared_resources_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe "SharedResources", type: :request do
+  describe 'POST /shared_resources' do
+    let(:user) { create(:user) }
+    let!(:project) { create(:project, user:) }
+    let(:other_user_project) { create(:project) }
+
+    describe 'when user is signed in' do
+      before do
+          sign_in(user)
+      end
+
+      context 'when shared resource is valid' do
+        it 'creates a shared resource' do
+            expect {
+                post '/shared_resources.json', params: { shared_resource: { shareable_id: project.id, shareable_type: 'Project', user_id: user.id, permission_level: 'full_access' } }
+            }.to change(SharedResource, :count).by(1)
+        end
+      end
+
+      context 'when shared resource is invalid' do
+        it 'returns unprocessable entity' do
+            post '/shared_resources.json', params: { shared_resource: { shareable_id: project.id, shareable_type: 'Project', user_id: user.id, permission_level: '' } }
+            expect(response).to be_unprocessable
+        end
+      end
+    end
+
+    context 'when user is not signed in' do
+        it 'returns unauthorized' do
+            post '/shared_resources.json', params: { shared_resource: { shareable_id:  project.id, shareable_type: 'Project', user_id:  user.id, permission_level: 'full_access' } }
+            expect(response).to be_unauthorized
+        end
+    end
+  end
+
+  describe 'PUT /shared_resources/:resource_id/:user_id/:resource_type' do
+    let(:user) { create(:user) }
+    let!(:project) { create(:project, user:) }
+    let(:shared_resource) { create(:shared_resource, shareable: project, user: user) }
+
+    describe 'when user is signed in' do
+      before do
+          sign_in(user)
+      end
+
+      context 'when shared resource is valid' do
+        it 'updates a shared resource' do
+            put "/shared_resources/#{project.id}/#{user.id}/Project.json", params: { shared_resource: { permission_level: 'view' } }
+            expect(shared_resource.reload.permission_level).to eq('view')
+        end
+      end
+
+      context 'when shared resource is invalid' do
+        it 'returns unprocessable entity' do
+            put "/shared_resources/#{project.id}/#{user.id}/Project.json", params: { shared_resource: { permission_level: '' } }
+            expect(response).to be_not_found
+        end
+      end
+    end
+
+    context 'when user is not signed in' do
+        it 'returns unauthorized' do
+            put "/shared_resources/#{project.id}/#{user.id}/Project.json", params: { shared_resource: { permission_level: 'view' } }
+            expect(response).to be_unauthorized
+        end
+    end
+  end
+
+  describe 'GET /shared_resources/:id' do
+    let(:user) { create(:user) }
+    let!(:project) { create(:project, user:) }
+    let(:shared_resource) { create(:shared_resource, shareable: project, user: user) }
+
+    describe 'when user is signed in' do
+      before do
+          sign_in(user)
+      end
+
+      it 'returns successful' do
+          get "/shared_resources/#{shared_resource.id}.json"
+          expect(response).to be_successful
+      end
+
+      it 'returns the shared resource' do
+          get "/shared_resources/#{shared_resource.id}.json"
+          expect(JSON.parse(response.body)['id']).to eq(shared_resource.id)
+      end
+    end
+
+    context 'when user is not signed in' do
+        it 'returns unauthorized' do
+            get "/shared_resources/#{shared_resource.id}.json"
+            expect(response).to be_unauthorized
+        end
+    end
+  end
+end

--- a/spec/requests/shared_resources_spec.rb
+++ b/spec/requests/shared_resources_spec.rb
@@ -46,16 +46,22 @@ RSpec.describe "SharedResources", type: :request do
       end
 
       context 'when shared resource is valid' do
+        let(:shared_resource) { create(:shared_resource, shareable: project, user: user) }
+
         it 'updates a shared resource' do
-            put "/shared_resources/#{project.id}/#{user.id}/Project.json", params: { shared_resource: { permission_level: 'view' } }
-            expect(shared_resource.reload.permission_level).to eq('view')
+          shared_resource
+          put "/shared_resources/Project/#{project.id}/#{user.id}.json", 
+              params: { shared_resource: { permission_level: 'view' } }
+          expect(response).to be_successful
+          expect(shared_resource.reload.permission_level).to eq('view')
         end
       end
 
       context 'when shared resource is invalid' do
         it 'returns unprocessable entity' do
-            put "/shared_resources/#{project.id}/#{user.id}/Project.json", params: { shared_resource: { permission_level: '' } }
-            expect(response).to be_not_found
+            put "/shared_resources/Project/#{project.id}/#{user.id}.json", 
+                params: { shared_resource: { permission_level: '' } }
+            expect(response).to be_unprocessable
         end
       end
     end


### PR DESCRIPTION
I tried to split my work into meaningful commits to make it easier to review.

### 1. Proposed solution
I created a polymorphic association to represent the ability to share resources between users.
This way it would be extensible to other models in the future as needed. 

![image](https://github.com/user-attachments/assets/cb48ae80-64c3-424c-86b7-85e4824d3890)

### 2. API
Based on the frontend I created 3 routes that will be required:
 - Create a Shared Resource
  ```
  POST /shared_resources

body
{ 
shared_resource: { shareable_id: project.id, shareable_type: 'Project', user_id: user.id, permission_level: 'full_access' }
}
```` 
 - Update a shared resource permission level
 ```
 PUT shared_resources/:resource_type/:resource_id/:user_id
body 
{
shared_resource: { permission_level: 'view}
}
```
 - Show Shared Resource
` GET /shared_resources/:id`

A list shared resources route will also be required in the future to list existing shared resources for a project, document, and report.
`GET /shared_resources/project/:project_id`

### 3. Issues Found 
I found a few issues when testing the app:
1 - The user id was not being returned so react was displaying a duplicate key error.
```
    {users?.map?.((user: User) => (
        <div key={user.id} className="flex items-center justify-between bg-gray-700 p-2 rounded">
```
2 - When a new user is created, the name is not currently required, AvatarFallback was also displaying an error.
  ```
  <Avatar>
        <AvatarImage src={user.avatar_url} alt={user.name} />
        <AvatarFallback>{user.name?.charAt(0)}</AvatarFallback>
    </Avatar>
```
3 - Devise views are showing an error, this one I did not fix, this due time constraints
```
Uncaught Error: createRoot(...): Target container is not a DOM element.
    createRoot http://localhost:5000/assets/application-9492d25cd2224e22fcc40e2e2c8776209622d4d6cc9bb478b68a50d103b9fc13.js:23104
```


### 4. Comments about the project itself
I ended up using a little bit more than 2 hours(about 2.5 hours). I tried to cover the backend mostly, and to add tests of scenarios that I saw fit.
I was able to create a model, and the API, and started listing shared user projects using the projects index API.
I manually created some shared projects to test using the frontend, and for the success scenario it worked well.

### 5. Next Steps

For something bigger than the scope of a take-home test I would not try to reinvent the wheel and use something like can can can.
Another thing I would do is do a proper authorization verification before executing any user actions.

1 - Replicate share Projects behavior to Documents and Reports.
2 - Implement API hooks on the frontend, then add actual functionality.
3 - Authorize user actions based on user permissions.
4 - Use authorization gem like pundit or can can can.

That was a fun project to do. It gave me a lot to reflect on the best way of implementing the solution to future-proof the implementation and how to choose what should be prioritized. In case you want to discuss anything further just let me know.

I used copilot to generate some of the tests, mainly for boilerplate code.