### PR TITLE
Taiguaras Take Home test

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,5 +8,21 @@ class UsersController < ApplicationController
     def current
         @user = current_user
     end
+
+    # def update
+    #     @user = User.find(params[:id])
+    #     if @user.update(user_params)
+    #         redirect_to @user, notice: "User was successfully updated."
+    #     else
+    #         redirect_to edit_user_path(@user), alert: "Failed to update user."
+    #     end
+    # end
+
+    # # Only allow a list of trusted parameters through.
+    # def user_params
+    #     params.require(:id).permit(:user_id)
+    # end
+
 end
   
+

--- a/app/javascript/app/api/useUpdateUser.ts
+++ b/app/javascript/app/api/useUpdateUser.ts
@@ -1,0 +1,25 @@
+import { Document } from "@/models";
+import { User } from "@/models";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { postHeaders } from "./helpers";
+export default function useUpdateUser(userId?: number | string, projectRole: string, reportRole: string, documentRole: string) {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: async (newUser: User) => {
+            const response = await fetch(`/users/${userId}.json`, {
+                method: 'PUT',
+                headers: postHeaders(),
+                body: JSON.stringify({ projectRole: projectRole, reportRole: reportRole, documentRole: documentRole }),
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to update user');
+            }
+
+            return response.json();
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['users', userId] })
+        },
+    })
+}

--- a/app/javascript/app/components/shared/ShareDialog.tsx
+++ b/app/javascript/app/components/shared/ShareDialog.tsx
@@ -2,34 +2,41 @@ import React, { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/ui/dialog"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/ui/select"
 import { Avatar, AvatarFallback, AvatarImage } from "@/ui/avatar"
+
 import { Button } from "@/ui/button"
 import { Input } from "@/ui/input"
 import { User } from '@/models';
+import { set } from 'date-fns';
 export default function ShareDialog({
     handleUpdateUserPermission,
     handleAddUser,
+    saveUserPermissions,
     isOpen,
     onClose,
     title = 'Share',
     users,
 }: {
-    handleUpdateUserPermission: (userId: number, permission: 'full access' | 'edit' | 'view') => void;
-    handleAddUser: () => void;
+    handleUpdateUserPermission: (userEmail: string, permission: 'admin' | 'edit' | 'view', resource: any, user:User) => void;
+    handleAddUser: (newUserEmail: string, permission: 'admin' | 'edit' | 'view') => void;
     isOpen: boolean;
     onClose: () => void;
     title?: string;
     users?: User[];
+    saveUserPermissions: (User);
 }) {
 
+    const [userList, setUserList] = useState(users);
+    const [userAux, setUserAux] = useState<User>();
     const [newUserEmail, setNewUserEmail] = useState('');
-    const [newUserPermission, setNewUserPermission] = useState<'full access' | 'edit' | 'view'>('view');
+    const [newUserPermission, setNewUserPermission] = useState<'admin' | 'edit' | 'view'>('view');
 
-    const getPermissionLabel = (permission: 'full access' | 'edit' | 'view' | undefined | null) => {
+    const getPermissionLabel = (permission: 'admin' | 'edit' | 'view' | undefined | null) => {
+        console.log("getPermissionLabel",permission);
         if (!permission) return 'Select permission';
 
         switch (permission) {
-            case 'full access':
-                return 'Full Access';
+            case 'admin':
+                return 'Admin'; 
             case 'edit':
                 return 'Edit';
             case 'view':
@@ -38,6 +45,32 @@ export default function ShareDialog({
                 return 'Select permission';
         }
     };
+
+    // PRONTO, é isso
+    const adicionaUsuario = (newUserEmail: string, permission: 'admin' | 'edit' | 'view') => {
+        console.log('adicionaUsuario', newUserEmail, permission);
+        handleAddUser(newUserEmail, permission);
+    }
+
+    const atualizaPermissao = (permissaoNova: any, userEmail:string, resource: any, user:User) => {
+        console.log('atualiza Permissao > ', userEmail, permissaoNova, resource, user);
+        setUserAux(permissaoNova);
+
+        if(resource == 'projectRole'){
+            user.projectRole = permissaoNova;
+        }
+
+        if(resource == 'documentRole'){
+            user.documentRole = permissaoNova;
+        }
+
+        if(resource == 'reportRole'){
+            user.reportRole = permissaoNova;
+        }
+
+        console.log('depois switch Permissao > ', user);
+        handleUpdateUserPermission(userEmail, permissaoNova, resource, user);
+    }
 
     return <Dialog open={isOpen} onOpenChange={onClose}>
         <DialogContent className="bg-gray-800 text-white border-gray-700 max-w-2xl">
@@ -52,14 +85,14 @@ export default function ShareDialog({
                         onChange={(e) => setNewUserEmail(e.target.value)}
                         className="bg-gray-700 text-white border-gray-600"
                     />
-                    <Select value={newUserPermission} onValueChange={(value: 'full access' | 'edit' | 'view') => setNewUserPermission(value)}>
+                    <Select value={newUserPermission} onValueChange={(value: 'admin' | 'edit' | 'view') => setNewUserPermission(value)}>
                         <SelectTrigger className="w-[200px] bg-gray-700 text-white border-gray-600">
-                            <SelectValue>{getPermissionLabel(newUserPermission)}</SelectValue>
+                            <SelectValue>{newUserPermission}</SelectValue>
                         </SelectTrigger>
                         <SelectContent className="bg-gray-700 text-white border-gray-600">
-                            <SelectItem value="full access">
+                            <SelectItem value="admin">
                                 <div className="flex flex-col">
-                                    <span>Full Access</span>
+                                    <span>admin</span>
                                     <span className="text-xs text-gray-400">Can edit and manage permissions</span>
                                 </div>
                             </SelectItem>
@@ -77,10 +110,15 @@ export default function ShareDialog({
                             </SelectItem>
                         </SelectContent>
                     </Select>
-                    <Button onClick={handleAddUser}>Add</Button>
+                    <Button onClick={() => adicionaUsuario(newUserEmail, newUserPermission)}>Add</Button>
                 </div>
                 <div className="space-y-2 max-h-96 overflow-y-auto">
+                    {/*
+                    Users iteration 
+                     */}
+
                     {users?.map?.((user: User) => (
+                        // (userAux? setUserAux(user): null ),
                         <div key={user.id} className="flex items-center justify-between bg-gray-700 p-2 rounded">
                             <div className="flex items-center space-x-2">
                                 <Avatar>
@@ -91,18 +129,20 @@ export default function ShareDialog({
                                     <p className="font-medium">{user.name}</p>
                                     <p className="text-sm text-gray-400">{user.email}</p>
                                 </div>
-                            </div>
-                            <Select
-                                value={user.permission}
-                                onValueChange={(value: 'full access' | 'edit' | 'view') => handleUpdateUserPermission(user.id, value)}
+
+                                <div className="permissionRole">
+                                <p className="text-sm text-gray-400 text-center">Projects</p>
+                                 <Select
+                                value={user.projectRole}
+                                onValueChange={(value: 'admin' | 'edit' | 'view') => atualizaPermissao(value, user.email, 'projectRole', user)}
                             >
-                                <SelectTrigger className="w-[200px] bg-gray-600 text-white border-gray-500">
-                                    <SelectValue>{getPermissionLabel(user.permission || null)}</SelectValue>
+                                <SelectTrigger className="bg-gray-600 text-white border-gray-500">
+                                    <SelectValue>{user.projectRole}</SelectValue>
                                 </SelectTrigger>
                                 <SelectContent className="bg-gray-700 text-white border-gray-600">
-                                    <SelectItem value="full access">
+                                    <SelectItem value="admin">
                                         <div className="flex flex-col">
-                                            <span>Full Access</span>
+                                            <span>admin</span>
                                             <span className="text-xs text-gray-400">Can edit and manage permissions</span>
                                         </div>
                                     </SelectItem>
@@ -120,8 +160,81 @@ export default function ShareDialog({
                                     </SelectItem>
                                 </SelectContent>
                             </Select>
+                                </div>
+
+
+
+                                <div className="permissionRole">
+                                <p className="text-sm text-gray-400 text-center">Documents</p>
+                                 <Select
+                                value={user.documentRole}
+                                onValueChange={(value: 'admin' | 'edit' | 'view') => atualizaPermissao(value, user.email, 'documentRole', user)}
+                            >
+                                <SelectTrigger className="bg-gray-600 text-white border-gray-500">
+                                    <SelectValue>{user.documentRole}</SelectValue>
+                                </SelectTrigger>
+                                <SelectContent className="bg-gray-700 text-white border-gray-600">
+                                    <SelectItem value="admin">
+                                        <div className="flex flex-col">
+                                            <span>admin</span>
+                                            <span className="text-xs text-gray-400">Can edit and manage permissions</span>
+                                        </div>
+                                    </SelectItem>
+                                    <SelectItem value="edit">
+                                        <div className="flex flex-col">
+                                            <span>Edit</span>
+                                            <span className="text-xs text-gray-400">Can make changes to the project</span>
+                                        </div>
+                                    </SelectItem>
+                                    <SelectItem value="view">
+                                        <div className="flex flex-col">
+                                            <span>View</span>
+                                            <span className="text-xs text-gray-400">Can only view the project</span>
+                                        </div>
+                                    </SelectItem>
+                                </SelectContent>
+                            </Select>
+                                </div>
+
+
+                                <div className="permissionRole">
+                                <p className="text-sm text-gray-400 text-center">Reports</p>
+                                 <Select
+                                value={user.reportRole}
+                                onValueChange={(value: 'admin' | 'edit' | 'view') => atualizaPermissao(value, user.email, 'reportRole', user)}
+                            >
+                                <SelectTrigger className="bg-gray-600 text-white border-gray-500">
+                                    <SelectValue>{user.reportRole}</SelectValue>
+                                </SelectTrigger>
+                                <SelectContent className="bg-gray-700 text-white border-gray-600">
+                                    <SelectItem value="admin">
+                                        <div className="flex flex-col">
+                                            <span>admin</span>
+                                            <span className="text-xs text-gray-400">Can edit and manage permissions</span>
+                                        </div>
+                                    </SelectItem>
+                                    <SelectItem value="edit">
+                                        <div className="flex flex-col">
+                                            <span>Edit</span>
+                                            <span className="text-xs text-gray-400">Can make changes to the project</span>
+                                        </div>
+                                    </SelectItem>
+                                    <SelectItem value="view">
+                                        <div className="flex flex-col">
+                                            <span>View</span>
+                                            <span className="text-xs text-gray-400">Can only view the project</span>
+                                        </div>
+                                    </SelectItem>
+                                </SelectContent>
+                            </Select>
+                                </div>
+                                <Button className='align-self-end' onClick={() => saveUserPermissions(user)}>Save</Button>
+                        </div>
                         </div>
                     ))}
+                    {/*
+                    Users iteration 
+                     */}
                 </div>
             </div>
         </DialogContent>

--- a/app/javascript/app/models/User.ts
+++ b/app/javascript/app/models/User.ts
@@ -3,5 +3,8 @@ export type User = {
     name: string;
     email: string;
     avatar_url?: string;
-    permission?: 'full access' | 'edit' | 'view';
+    projectRole?: 'admin' | 'editor' | 'viewer';
+    reportRole?: 'admin' | 'editor' | 'viewer';
+    documentRole?: 'admin' | 'editor' | 'viewer';
+    permission?: 'admin' | 'edit' | 'view';
 }

--- a/app/views/users/_user.json.jbuilder
+++ b/app/views/users/_user.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! user, :name, :avatar_url, :email, :created_at, :updated_at
+json.extract!  user,:id, :name, :avatar_url, :email, :created_at, :updated_at, :projectRole, :documentRole, :reportRole

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     resources :reports
   end
 
-  resources :users, only: [:index]
+  resources :users, only: [:index, :update]
 
   devise_for :users
   root 'home#index'

--- a/db/migrate/20241108044359_add_roles_to_users.rb
+++ b/db/migrate/20241108044359_add_roles_to_users.rb
@@ -1,0 +1,7 @@
+class AddRolesToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :projectRole, :string
+    add_column :users, :reportRole, :string
+    add_column :users, :documentRole, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_25_221451) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_08_044359) do
   create_table "documents", force: :cascade do |t|
     t.string "name"
     t.integer "project_id", null: false
@@ -50,6 +50,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_25_221451) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.text "avatar_url"
+    t.string "projectRole"
+    t.string "reportRole"
+    t.string "documentRole"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,25 +12,37 @@
     "name": "Tyler Durden",
     "avatar_url": "https://avatar.iran.liara.run/username?username=tyler+durden",
     "email": "tylerdurden@example.com",
-    "password": "testing123"
+    "password": "testing123",
+    "projectRole": "admin",
+    "documentRole": "admin",
+    "reportRole": "admin"
 },
 {
     "name": "Jack Durden",
     "avatar_url": "https://avatar.iran.liara.run/username?username=jack+durden",
     "email": "jackdurden@example.com",
-    "password": "testing123"
+    "password": "testing123",
+    "projectRole": "edit",
+    "documentRole": "edit",
+    "reportRole": "edit"
 },
 {
     "name": "Marla Singer",
     "avatar_url": "https://avatar.iran.liara.run/username?username=marla+singer",
     "email": "marlasinger@example.com",
-    "password": "testing123"
+    "password": "testing123",
+    "projectRole": "view",
+    "documentRole": "view",
+    "reportRole": "edit"
 },
 {
     "name": "Robert Paulson",
     "avatar_url": "https://avatar.iran.liara.run/username?username=robert+paulson",
     "email": "robertpaulson@example.com",
-    "password": "testing123"
+    "password": "testing123",
+    "projectRole": "admin",
+    "documentRole": "admin",
+    "reportRole": "admin"
 }].each do |user|
     User.create(user)
 end


### PR DESCRIPTION
## Overview
To handle the permission feature `ShareDialog` started to be refactored in order to display and change permission for each of those elements regardless of the object clicked. I did not have time to finish complete refactoring in order to clean the Reports and Documents, but I was able to make progress with Project.

User now has three attributes that define permission for each layer of resources.

`roleProjects`, `roleReports` and `roleDocuments`, which can be classified into levels: `admin`, `write`, `read`, `null`

Admin can manage permissions
Write can change resources
Read can only view it
Null can't see it

I started doing with a Permissions table like this `{permission_id, user_id, permission_type, resource_id}` but for each resource I had to query the resource permission level by `resource_id` and with a larger set of resources that could grow significantly the number of requests without mentioning the size of the Permissions table.  
I decided to take this approach inserting it on the user table directly because we already have a query for users happening and just some more params there will not be that impactful. Same goes for the table User.

I also added some checks before rendering a resource to display it or not based on the user permission.
I left a lot of console.logs to illustrate the thought process but usually when pushing it live there is a cleaning step of those.

### Things to build next:
Connect add user endpoint
Connect save button enpoint
Fix ShareDialog permission input refresh button rate
Tests

